### PR TITLE
top-level state machine, etc

### DIFF
--- a/GSP420 Team Project/GSP420 Team Project.vcxproj
+++ b/GSP420 Team Project/GSP420 Team Project.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="BaseRecipient.h" />
     <ClInclude Include="DepthBatch.h" />
     <ClInclude Include="Font.h" />
+    <ClInclude Include="Game.h" />
     <ClInclude Include="Graphics.h" />
     <ClInclude Include="GraphicsCore.h" />
     <ClInclude Include="GSPMessage.h" />
@@ -36,6 +37,8 @@
     <ClInclude Include="MessageHandler.h" />
     <ClInclude Include="Plane.h" />
     <ClInclude Include="RenderObject.h" />
+    <ClInclude Include="Scene.h" />
+    <ClInclude Include="SharedStore.h" />
     <ClInclude Include="Song.h" />
     <ClInclude Include="Sound.h" />
     <ClInclude Include="Sprite.h" />
@@ -44,6 +47,7 @@
     <ClInclude Include="TestText_temp.h" />
     <ClInclude Include="Text.h" />
     <ClInclude Include="Texture.h" />
+    <ClInclude Include="Timer.h" />
     <ClInclude Include="Utility.h" />
   </ItemGroup>
   <ItemGroup>
@@ -55,6 +59,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="Font.cpp" />
+    <ClCompile Include="Game.cpp" />
     <ClCompile Include="Graphics.cpp" />
     <ClCompile Include="GraphicsCore.cpp" />
     <ClCompile Include="GSPWindow.cpp" />
@@ -66,6 +71,8 @@
     <ClCompile Include="MenuManager.cpp" />
     <ClCompile Include="MessageHandler.cpp" />
     <ClCompile Include="Plane.cpp" />
+    <ClCompile Include="Scene.cpp" />
+    <ClCompile Include="SharedStore.cpp" />
     <ClCompile Include="Song.cpp" />
     <ClCompile Include="Sound.cpp" />
     <ClCompile Include="Sprite.cpp" />
@@ -74,6 +81,7 @@
     <ClCompile Include="TestText_temp.cpp" />
     <ClCompile Include="Text.cpp" />
     <ClCompile Include="Texture.cpp" />
+    <ClCompile Include="Timer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="buttons.png">

--- a/GSP420 Team Project/GSP420 Team Project.vcxproj.filters
+++ b/GSP420 Team Project/GSP420 Team Project.vcxproj.filters
@@ -13,12 +13,6 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Header Files\Testing">
-      <UniqueIdentifier>{6faad531-fce8-4b57-b0a5-4d7962c7ed00}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Source Files\Testing">
-      <UniqueIdentifier>{8aa8c8af-bc69-4c5e-ae37-09ca609fed2e}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Header Files\Engine">
       <UniqueIdentifier>{72999b13-a16f-48fc-ba91-fa69ffc344e8}</UniqueIdentifier>
     </Filter>
@@ -55,6 +49,24 @@
     <Filter Include="Source Files\Engine\Audio">
       <UniqueIdentifier>{7ec0569b-0dcd-40b4-98e7-9ff45b3b0dd1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Game">
+      <UniqueIdentifier>{f645ea19-df7a-481a-b33c-86f8c5405258}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Game">
+      <UniqueIdentifier>{55ad5028-b200-448a-8014-66cd4d7dc8c7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Game\Scenes">
+      <UniqueIdentifier>{5daaf94a-4f1d-41d4-8760-a62c6174d608}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Game\Scenes">
+      <UniqueIdentifier>{db5f6604-f01a-4761-ad91-a98641597b34}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Game\Scenes\TestScene">
+      <UniqueIdentifier>{a1b4baa8-d2ab-45d3-96db-ff56f31bb73b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Game\Scenes\TestScene">
+      <UniqueIdentifier>{6faad531-fce8-4b57-b0a5-4d7962c7ed00}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Font.h">
@@ -90,9 +102,6 @@
     <ClInclude Include="GSPMessage.h">
       <Filter>Header Files\Engine\Messaging</Filter>
     </ClInclude>
-    <ClInclude Include="Utility.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Sprite.h">
       <Filter>Header Files\Engine\Graphics</Filter>
     </ClInclude>
@@ -106,13 +115,10 @@
       <Filter>Header Files\Engine\Graphics</Filter>
     </ClInclude>
     <ClInclude Include="Stella_temp.h">
-      <Filter>Header Files\Testing</Filter>
+      <Filter>Header Files\Game\Scenes\TestScene</Filter>
     </ClInclude>
     <ClInclude Include="TestText_temp.h">
-      <Filter>Header Files\Testing</Filter>
-    </ClInclude>
-    <ClInclude Include="TestScene.h">
-      <Filter>Header Files\Testing</Filter>
+      <Filter>Header Files\Game\Scenes\TestScene</Filter>
     </ClInclude>
     <ClInclude Include="GraphicsCore.h">
       <Filter>Header Files\Engine\Cores</Filter>
@@ -134,6 +140,24 @@
     </ClInclude>
     <ClInclude Include="Song.h">
       <Filter>Header Files\Engine\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Utility.h">
+      <Filter>Header Files\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="SharedStore.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Game.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Scene.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="Timer.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="TestScene.h">
+      <Filter>Header Files\Game\Scenes</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -179,15 +203,6 @@
     <ClCompile Include="DepthBatch.cpp">
       <Filter>Source Files\Engine\Graphics</Filter>
     </ClCompile>
-    <ClCompile Include="Stella_temp.cpp">
-      <Filter>Source Files\Testing</Filter>
-    </ClCompile>
-    <ClCompile Include="TestText_temp.cpp">
-      <Filter>Source Files\Testing</Filter>
-    </ClCompile>
-    <ClCompile Include="TestScene.cpp">
-      <Filter>Source Files\Testing</Filter>
-    </ClCompile>
     <ClCompile Include="GSPWindow.cpp">
       <Filter>Source Files\Engine\Graphics</Filter>
     </ClCompile>
@@ -208,6 +223,27 @@
     </ClCompile>
     <ClCompile Include="Song.cpp">
       <Filter>Source Files\Engine\Audio</Filter>
+    </ClCompile>
+    <ClCompile Include="SharedStore.cpp">
+      <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="Game.cpp">
+      <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="Scene.cpp">
+      <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="Timer.cpp">
+      <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="TestScene.cpp">
+      <Filter>Source Files\Game\Scenes</Filter>
+    </ClCompile>
+    <ClCompile Include="Stella_temp.cpp">
+      <Filter>Source Files\Game\Scenes\TestScene</Filter>
+    </ClCompile>
+    <ClCompile Include="TestText_temp.cpp">
+      <Filter>Source Files\Game\Scenes\TestScene</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/GSP420 Team Project/Game.cpp
+++ b/GSP420 Team Project/Game.cpp
@@ -1,0 +1,36 @@
+#include "Game.h"
+#include "TestScene.h"
+#include "MessageHandler.h"
+
+Game::Game() :
+  scene(new TestScene(&store))
+{
+  //nop
+}
+
+void Game::run() {
+  timer.getDT();
+
+  while(scene && store.window.update()) {
+    store.input.ReadFrame();
+
+    if(store.input.MouseMoved()) { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 0)); }
+    if(store.input.IsMouseTriggered(InputManager::MOUSE_LEFT)) { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 1)); }
+    if(store.input.IsMouseReleased(InputManager::MOUSE_LEFT))  { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 2)); }
+    if(store.input.IsKeyTriggered(InputManager::KEY_ENTER))    { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 3)); }
+    if(store.input.IsKeyTriggered(InputManager::KEY_UP))       { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 4)); }
+    if(store.input.IsKeyTriggered(InputManager::KEY_DOWN))     { gMessageHandler->HandleMessage(new GSPMessage(store.msgTgt, 5)); }
+
+    Scene* next = scene->update(timer.getDT());
+
+    if(next == scene.get()) {
+      store.gfx.startDraw();
+      scene->draw();
+      store.gfx.endDraw();
+    }
+    else {
+      scene.reset(next);
+    }
+
+  }
+}

--- a/GSP420 Team Project/Game.h
+++ b/GSP420 Team Project/Game.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "SharedStore.h"
+#include "Timer.h"
+#include "Scene.h"
+#include <memory>
+
+class Game {
+public:
+  Game();
+  void run();
+
+private:
+  Timer timer;
+  SharedStore store;
+  std::unique_ptr<Scene> scene;
+
+};

--- a/GSP420 Team Project/Scene.cpp
+++ b/GSP420 Team Project/Scene.cpp
@@ -1,0 +1,14 @@
+#include "Scene.h"
+#include "SharedStore.h"
+
+Scene::Scene(SharedStore* store) :
+  store(store),
+  menu(store->input)
+{
+  //nop
+}
+
+Scene::~Scene() {
+  //nop
+}
+

--- a/GSP420 Team Project/Scene.h
+++ b/GSP420 Team Project/Scene.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "MenuManager.h"
+
+struct SharedStore;
+
+class Scene {
+public:
+  Scene(SharedStore* store);
+  virtual ~Scene();
+  virtual Scene* update(float dt) = 0;
+  virtual void draw() = 0;
+
+  MenuManager menu;
+
+protected:
+  SharedStore* store;
+
+};

--- a/GSP420 Team Project/SharedStore.cpp
+++ b/GSP420 Team Project/SharedStore.cpp
@@ -1,0 +1,10 @@
+#include "SharedStore.h"
+#include "MessageHandler.h"
+
+SharedStore::SharedStore() :
+  window(L"Testing Window", screenWidth, screenHeight),
+  gfx(window),
+  input(window)
+{
+  gMessageHandler->Instantiate();
+}

--- a/GSP420 Team Project/SharedStore.h
+++ b/GSP420 Team Project/SharedStore.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "GSPWindow.h"
+#include "Graphics.h"
+#include "InputManager.h"
+#include "Audio.h"
+#include "GSPMessage.h"
+
+struct SharedStore {
+  SharedStore();
+
+  //the order of these declarations is important.
+  //please do not rearrange them.
+  
+  //misc data
+  const int screenWidth = 1080;
+  const int screenHeight = 600;
+  RClass msgTgt = RTESTMENU;
+
+  //systems
+  GSPWindow window;
+  Graphics gfx;
+  InputManager input;
+  Audio audio;
+
+};

--- a/GSP420 Team Project/TestScene.cpp
+++ b/GSP420 Team Project/TestScene.cpp
@@ -1,13 +1,13 @@
 #include "TestScene.h"
 #include "MessageHandler.h"
 #include "InputManager.h"
+#include "SharedStore.h"
 
-TestScene::TestScene(InputManager& inputMgr, int screenWidth, int screenHeight) :
-  input(&inputMgr),
+TestScene::TestScene(SharedStore* store) :
+  Scene(store),
   font(L"Arial"),
   staticText(L"GSP420 Week 4 Demo\nUse buttons or press 'S' to walk.", &font),
   bgtex(L"tilesetOpenGameBackground_3.png"),
-  menu(inputMgr),
   snd("SFX/button-37.mp3"),
   song("BGM/Undaunted.mp3")
 {
@@ -38,7 +38,7 @@ TestScene::TestScene(InputManager& inputMgr, int screenWidth, int screenHeight) 
   btnSpr[0].srcRect.height /= 3;
 
   btnSpr[0].destRect = btnSpr[0].srcRect;
-  btnSpr[0].destRect.x = screenWidth - (btnSpr[0].srcRect.width  + 20);
+  btnSpr[0].destRect.x = store->screenWidth - (btnSpr[0].srcRect.width  + 20);
   btnSpr[0].destRect.y = 20;
 
   //make copies and adjust them
@@ -69,26 +69,20 @@ TestScene::TestScene(InputManager& inputMgr, int screenWidth, int screenHeight) 
   }
 }
 
-bool TestScene::update() {
-  if(input->IsKeyPressed(InputManager::KEY_ESC)) { return false; }
+TestScene::~TestScene() {
+  //gMessageHandler->RemoveRecipient(RTESTMENU);
+}
 
-  if(input->MouseMoved())                               { gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 0)); }
-  if(input->IsMouseTriggered(InputManager::MOUSE_LEFT)) {
-    gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 1));
-    snd.play();
-  }
-  if(input->IsMouseReleased(InputManager::MOUSE_LEFT))  { gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 2)); }
-  if(input->IsKeyTriggered(InputManager::KEY_ENTER))    { gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 3)); }
-  if(input->IsKeyTriggered(InputManager::KEY_UP))       { gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 4)); }
-  if(input->IsKeyTriggered(InputManager::KEY_DOWN))     { gMessageHandler->HandleMessage(new GSPMessage(RTESTMENU, 5)); }
-
-  if(input->IsKeyPressed(InputManager::KEY_S)) { gMessageHandler->HandleMessage(new GSPMessage(RSTELLA, Stella::WALK)); }
-
+Scene* TestScene::update(float dt) {
   menu.Update();
+
+  if(store->input.IsKeyPressed(InputManager::KEY_ESC)) { return nullptr; }
+  if(store->input.IsKeyPressed(InputManager::KEY_S)) { gMessageHandler->HandleMessage(new GSPMessage(RSTELLA, Stella::WALK)); }
+
   stella.update();
   plane.scrollx += 2;
 
-  return true;
+  return this;
 }
 
 void TestScene::draw() {

--- a/GSP420 Team Project/TestScene.h
+++ b/GSP420 Team Project/TestScene.h
@@ -1,21 +1,20 @@
 #pragma once
 #include "Plane.h"
 #include "DepthBatch.h"
-#include "MenuManager.h"
 #include "Stella_temp.h"
 #include "Text.h"
 #include "Font.h"
 #include "Sprite.h"
 #include "Audio.h"
 #include "Sound.h"
+#include "Scene.h"
 
-class InputManager;
-
-class TestScene {
+class TestScene : public Scene {
 public:
-  TestScene(InputManager& inputMgr, int screenWidth, int screenHeight);
-  bool update();
-  void draw();
+  TestScene(SharedStore* store);
+  ~TestScene();
+  Scene* update(float dt) override;
+  void draw() override;
 
 private:
   Sound snd;
@@ -26,9 +25,6 @@ private:
   Texture bgtex;
   Plane plane;
   DepthBatch batch;
-  MenuManager menu;
   std::vector<Text> menuLabels;
-
-  InputManager* input;
 
 };

--- a/GSP420 Team Project/Timer.cpp
+++ b/GSP420 Team Project/Timer.cpp
@@ -1,0 +1,18 @@
+#include "Timer.h"
+#include <Windows.h>
+
+Timer::Timer() {
+  QueryPerformanceFrequency((LARGE_INTEGER*)&freq);
+  QueryPerformanceCounter((LARGE_INTEGER*)&prev);
+}
+
+float Timer::getDT() {
+  __int64 now;
+  QueryPerformanceCounter((LARGE_INTEGER*)&now);
+
+  float seconds = float(now - prev) / freq;
+
+  prev = now;
+
+  return seconds;
+}

--- a/GSP420 Team Project/Timer.h
+++ b/GSP420 Team Project/Timer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class Timer {
+public:
+  Timer();
+  float getDT();
+
+private:
+  __int64 prev, freq;
+
+};

--- a/GSP420 Team Project/main.cpp
+++ b/GSP420 Team Project/main.cpp
@@ -22,34 +22,11 @@
 //edited 5/26/2016 at 11:33 AM EST by Derek
 //to update MenuButton+MenuManager to GSPRect and attempt fixing an issue with buttons failing to draw properly
 
-#include "GSPWindow.h"
-#include "Graphics.h"
-#include "InputManager.h"
-#include "MessageHandler.h"
-#include "TestScene.h"
-#include "Audio.h"
+#include "Game.h"
 
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int){
-  GSPWindow gameWindow(L"Testing Window", 1080, 600);
-  Graphics gfx(gameWindow);
-  InputManager input(gameWindow);
-  Audio audio;
-  gMessageHandler->Instantiate();
-
-  TestScene scene(input, gameWindow.WIDTH, gameWindow.HEIGHT);
-
-  while(gameWindow.update()) {
-	  input.ReadFrame();
-
-    if(scene.update()) {
-  	  gfx.startDraw();
-      scene.draw();
-      gfx.endDraw();
-    }
-    else {
-      break;
-    }
-  }
+  Game game;
+  game.run();
 
 	return 0;
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
 # GSP420-Team-Project
-
-
-This is the updated Repository, created with Visual Studio.
-Currently contains the GSPWindow class.


### PR DESCRIPTION
Please note that TestScene has been altered to fit within the state machine. Feel free to use it for transition testing. Note that input signals are sent to menu objects from Game::run(). This may need a little fiddling with, but a scene should set the target ID of its menu in store->msgTgt when it constructs.
